### PR TITLE
Create Makefile.osx

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -62,7 +62,7 @@ S4r_LIBNAME = $(OBJDIR)/libS4r.a
 
 #### Set the compilation flags
 
-CPPFLAGS = -I. -IS4 -IS4/RNP -IS4/kiss_fft #-static
+CPPFLAGS = -I. -IS4 -IS4/RNP -IS4/kiss_fft 
 
 ifdef BLAS_LIB
 CPPFLAGS += -DHAVE_BLAS

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,7 +1,8 @@
 # To build:
 #   make <target>
-# Use the 'lib' target first to build the library, then either the Lua
-# or Python targets are 'S4lua' and 'python_ext', respectively.
+# Use either 'S4lua' for Lua, or 'python_ext' for Python.
+# S4lua also builds FunctionSampler1D and FunctionSampler2D, in modules.
+# You can build the sampler seperately with 'make sampler'
 
 # Set these to the flags needed to link against BLAS and Lapack.
 #  If left blank, then performance may be very poor.
@@ -18,14 +19,14 @@ LAPACK_LIB = -framework Accelerate
 #  On Debian,
 #   LUA_INC = -I/usr/include/lua5.2
 #   LUA_LIB = -llua5.2 -ldl -lm
-LUA_INC = -Ilua-5.2.3/install/include
-LUA_LIB = -Llua-5.2.3/install/lib -llua -lm
+LUA_INC = -I./lua-5.2.3/install/include
+LUA_LIB = -L./lua-5.2.3/install/lib -llua -ldl
 
 # Typically if installed,
 #  FFTW3_INC can be left empty
 #  FFTW3_LIB = -lfftw3
 FFTW3_INC =
-FFTW3_LIB = 
+FFTW3_LIB =
 
 # Typically,
 #  PTHREAD_INC = -DHAVE_UNISTD_H -lpthread
@@ -34,7 +35,7 @@ PTHREAD_INC =  -DHAVE_UNISTD_H -lpthread
 PTHREAD_LIB = -lpthread
 
 # Typically if installed,
-#  CHOLMOD_INC = -I/usr/include/suitesparse
+#  CHOLMOD_INC = -I/usr/local/include
 #  CHOLMOD_LIB = -lcholmod -lamd -lcolamd -lcamd -lccolamd
 CHOLMOD_INC = 
 CHOLMOD_LIB = 
@@ -49,6 +50,9 @@ CC  = gcc
 
 CFLAGS = -O3 -fPIC
 
+# options for Sampler module
+OPTFLAGS = -O3
+
 OBJDIR = ./build
 S4_BINNAME = $(OBJDIR)/S4
 S4_LIBNAME = $(OBJDIR)/libS4.a
@@ -58,7 +62,7 @@ S4r_LIBNAME = $(OBJDIR)/libS4r.a
 
 #### Set the compilation flags
 
-CPPFLAGS = -I. -IS4 -IS4/RNP -IS4/kiss_fft
+CPPFLAGS = -I. -IS4 -IS4/RNP -IS4/kiss_fft #-static
 
 ifdef BLAS_LIB
 CPPFLAGS += -DHAVE_BLAS
@@ -94,6 +98,7 @@ objdir:
 	mkdir -p $(OBJDIR)
 	mkdir -p $(OBJDIR)/S4k
 	mkdir -p $(OBJDIR)/S4r
+	mkdir -p $(OBJDIR)/modules
 
 S4_LIBOBJS = \
 	$(OBJDIR)/S4k/S4.o \
@@ -230,7 +235,8 @@ $(OBJDIR)/S4r/predicates.o: S4r/predicates.c
 
 $(OBJDIR)/S4k/main_lua.o: S4/main_lua.c objdir
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(LUA_INC) $< -o $@
-S4lua: $(OBJDIR)/S4k/main_lua.o $(S4_LIBNAME)
+
+S4lua: $(OBJDIR)/S4k/main_lua.o $(S4_LIBNAME) sampler
 	$(CXX) $(CFLAGS) $(CPPFLAGS) $< -o $(S4_BINNAME) $(S4_LIBNAME) $(LIBS) $(LUA_LIB)
 
 $(OBJDIR)/S4r/main_lua.o: S4r/main_lua.c
@@ -241,6 +247,17 @@ $(OBJDIR)/S4r/S4r.o: S4r/S4r.cpp
 	$(CXX) -c $(CFLAGS) $(CPPFLAGS) $(LUA_INC) $< -o $@
 S4rlua: objdir $(OBJDIR)/S4r/main_lua.o $(OBJDIR)/S4r/lua_named_arg.o $(OBJDIR)/S4r/S4r.o $(S4r_LIBNAME)
 	$(CXX) $(CFLAGS) $(CPPFLAGS) $(OBJDIR)/S4r/main_lua.o $(OBJDIR)/S4r/lua_named_arg.o $(OBJDIR)/S4r/S4r.o -o $@ $(S4r_LIBNAME) $(LIBS) $(LUA_LIB)
+
+sampler: FunctionSampler1D.so FunctionSampler2D.so
+FunctionSampler1D.so: modules/function_sampler_1d.c modules/function_sampler_1d.h modules/lua_function_sampler_1d.c
+	gcc -c $(OPTFLAGS) -fpic -Wall -I. modules/function_sampler_1d.c -o $(OBJDIR)/modules/function_sampler_1d.o
+	gcc $(OPTFLAGS) -bundle -undefined dynamic_lookup -fpic -Wall $(LUA_INC) -o $(OBJDIR)/FunctionSampler1D.so $(OBJDIR)/modules/function_sampler_1d.o modules/lua_function_sampler_1d.c 
+FunctionSampler2D.so: modules/function_sampler_2d.c modules/function_sampler_2d.h modules/lua_function_sampler_2d.c
+	gcc -c $(OPTFLAGS) -fpic -Wall -I. modules/function_sampler_2d.c -o $(OBJDIR)/modules/function_sampler_2d.o
+	gcc -c -O2 -fpic -Wall -I. modules/predicates.c -o $(OBJDIR)/modules/mod_predicates.o
+	gcc $(OPTFLAGS) -bundle -undefined dynamic_lookup -fpic -Wall $(LUA_INC) -o $(OBJDIR)/FunctionSampler2D.so $(OBJDIR)/modules/function_sampler_2d.o $(OBJDIR)/modules/mod_predicates.o modules/lua_function_sampler_2d.c
+
+
 
 #### Python extension
 

--- a/modules/Makefile.osx
+++ b/modules/Makefile.osx
@@ -1,0 +1,15 @@
+OPTFLAGS = -O3
+LUA_INCLUDE = -I../lua-5.2.3/install/include
+LUA_LIB = -L../lua-5.2.3/install/lib -llua
+OBJ_DIR = build
+
+all: FunctionSampler1D.so FunctionSampler2D.so
+FunctionSampler1D.so: function_sampler_1d.c function_sampler_1d.h lua_function_sampler_1d.c
+	gcc -c $(OPTFLAGS) -fpic -Wall -I. function_sampler_1d.c -o function_sampler_1d.o
+	gcc $(OPTFLAGS) -bundle -undefined dynamic_lookup -fpic -Wall $(LUA_INCLUDE) -o ../$(OBJ_DIR)/FunctionSampler1D.so function_sampler_1d.o lua_function_sampler_1d.c 
+FunctionSampler2D.so: function_sampler_2d.c function_sampler_2d.h lua_function_sampler_2d.c
+	gcc -c $(OPTFLAGS) -fpic -Wall -I. function_sampler_2d.c -o function_sampler_2d.o
+	gcc -c -O2 -fpic -Wall -I. predicates.c -o mod_predicates.o
+	gcc $(OPTFLAGS) -bundle -undefined dynamic_lookup -fpic -Wall $(LUA_INCLUDE) -o ../$(OBJ_DIR)/FunctionSampler2D.so function_sampler_2d.o mod_predicates.o lua_function_sampler_2d.c 
+clean:
+	rm -f ../$(OBJ_DIR)/FunctionSampler2D.so ../$(OBJ_DIR)/FunctionSampler1D.so *.o


### PR DESCRIPTION
S4/Makefile.osx compiles the FunctionSampler*D functions from S4/modules, when building S4lua.

S4/modules/Makefile.osx fixes the "Multiple lua VMs" error I got in compiling on Yosemite and Mavericks with the previous Makefile. Also, now puts FunctionSampler1D.so and FunctionSampler2D.so in ../build, with the rest of the executables.